### PR TITLE
feat: Add (:::) and (::?) synonyms ...

### DIFF
--- a/json-spec.cabal
+++ b/json-spec.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                json-spec
-version:             0.4.0.0
+version:             0.4.1.0
 synopsis:            Type-level JSON specification
 maintainer:          rick@owensmurray.com
 description:         See the README at: https://github.com/owensmurray/json-spec#json-spec

--- a/src/Data/JsonSpec.hs
+++ b/src/Data/JsonSpec.hs
@@ -79,7 +79,9 @@ module Data.JsonSpec (
   eitherDecode,
   encode,
   StructureFromJSON,
-  FieldSpec(..)
+  FieldSpec(..),
+  (:::),
+  (::?),
 ) where
 
 
@@ -91,8 +93,8 @@ import Data.JsonSpec.Encode (HasJsonEncodingSpec(EncodingSpec,
 import Data.JsonSpec.Spec (Field(Field, unField), FieldSpec(Optional,
   Required), Rec(Rec, unRec), Specification(JsonArray, JsonBool,
   JsonDateTime, JsonEither, JsonInt, JsonLet, JsonNullable, JsonNum,
-  JsonObject, JsonRaw, JsonRef, JsonString, JsonTag), Tag(Tag),
-  JSONStructure)
+  JsonObject, JsonRaw, JsonRef, JsonString, JsonTag), Tag(Tag), (:::),
+  (::?), JSONStructure)
 import Prelude ((.), (<$>), (=<<))
 
 

--- a/src/Data/JsonSpec/Spec.hs
+++ b/src/Data/JsonSpec/Spec.hs
@@ -16,6 +16,8 @@ module Data.JsonSpec.Spec (
   Rec(..),
   JStruct,
   FieldSpec(..),
+  (:::),
+  (::?),
 ) where
 
 
@@ -177,6 +179,14 @@ data Specification
 data FieldSpec
   = Required Symbol Specification {-^ The field is required -}
   | Optional Symbol Specification {-^ The field is optionsl -}
+
+
+{-| Alias for 'Required'. -}
+type (:::) = Required
+
+
+{-| Alias for 'Optional'. -}
+type (::?) = Optional
 
 
 {- |

--- a/test/jsonspec.hs
+++ b/test/jsonspec.hs
@@ -11,19 +11,28 @@
 {-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS_GHC -Wwarn #-} {- Because of GHC-69797 -}
+{-# OPTIONS_GHC -Werror=missing-import-lists #-}
 
 module Main (main) where
 
 import Control.Monad (join)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.ByteString.Lazy (ByteString)
-import Data.JsonSpec 
+import Data.JsonSpec (Field(Field, unField), FieldSpec(Optional,
+  Required), HasJsonDecodingSpec(DecodingSpec, fromJSONStructure),
+  HasJsonEncodingSpec(EncodingSpec, toJSONStructure), Rec(Rec, unRec),
+  SpecJSON(SpecJSON), Specification(JsonArray, JsonBool, JsonDateTime,
+  JsonEither, JsonInt, JsonLet, JsonNullable, JsonNum, JsonObject,
+  JsonRaw, JsonRef, JsonString, JsonTag), Tag(Tag), (:::), (::?),
+  eitherDecode, encode)
 import Data.Proxy (Proxy(Proxy))
 import Data.Scientific (Scientific)
 import Data.Text (Text)
 import Data.Time (UTCTime(UTCTime))
 import OM.Show (ShowJ(ShowJ))
-import Prelude 
+import Prelude (Applicative(pure), Bool(False, True), Either(Left,
+  Right), Enum(toEnum), Functor(fmap), Maybe(Just, Nothing), Monad((>>=)),
+  Traversable(traverse), ($), (.), Eq, IO, Int, Show, String, realToFrac)
 import Test.Hspec (describe, hspec, it, shouldBe)
 import qualified Data.Aeson as A
 
@@ -364,7 +373,7 @@ main =
               A.eitherDecode
                 "{ \"foo\": { \"bar\": \"barval\", \"baz\": [ \"qux\", 1, false ] } }"
               >>=
-                eitherDecode (Proxy @( JsonObject '[ Required "foo" JsonRaw ]))
+                eitherDecode (Proxy @( JsonObject '[ "foo" ::: JsonRaw ]))
           in
             actual `shouldBe` expected
         it "encodes" $
@@ -677,7 +686,7 @@ data TestOptionality = TestOptionality
 instance HasJsonEncodingSpec TestOptionality where
   type EncodingSpec TestOptionality =
     JsonObject
-      '[ Optional "foo" JsonInt
+      '[ "foo" ::? JsonInt
        , Required "bar" (JsonNullable JsonInt)
        , Optional "baz" (JsonNullable JsonInt)
        , Required "qux" JsonInt

--- a/test/jsonspec.hs
+++ b/test/jsonspec.hs
@@ -389,7 +389,7 @@ main =
                   ())
           in
             actual `shouldBe` expected
-          
+
 
 sampleTestObject :: TestObj
 sampleTestObject =


### PR DESCRIPTION
... for the 'Required' and 'Optional' data constructors, respectively.