### PR TITLE
JsonEither: list form and nested Either structural type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.3.0.0
+
 ### JsonEither now takes a type-level list
 
 `JsonEither` now accepts a type-level list of specs (`JsonEither '[a, b, c]`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+## Unreleased
+
+### JsonEither now takes a type-level list
+
+`JsonEither` now accepts a type-level list of specs (`JsonEither '[a, b, c]`)
+instead of two arguments (`JsonEither a b`), so sum types with many branches
+no longer require a binary tree of nested `JsonEither`s. The structural type
+for `JsonEither` is nested `Either`: two or more branches map to
+`Either (JStruct env a) (Either (JStruct env b) ...)`; a single branch maps
+to `JStruct env spec` (no sum wrapper). Use `Left`/`Right` for construction
+and pattern matching.
+
+#### Migration guide
+
+**Specs (example: four alternatives)**
+
+Before:
+
+```
+JsonEither (JsonEither (JsonEither specA specB) specC) specD
+```
+
+After:
+
+```
+JsonEither '[specA, specB, specC, specD]
+```
+
+**Patterns/construction**
+
+**Note:** The only difference in the pattern/construction may be how
+the `Either`s are nested. The two examples below represent the same
+four alternatives with different `Left`/`Right` nesting; the JSON and
+types are equivalent.
+
+Before (four branches):
+
+```
+Left (Left (Left val))
+Left (Left (Right val))
+Left (Right val)
+Right val
+```
+
+After (same nesting with `Left`/`Right`; one branch = no wrapper):
+
+```
+Left val
+Right (Left val)
+Right (Right (Left val))
+Right (Right (Right val))
+```

--- a/json-spec.cabal
+++ b/json-spec.cabal
@@ -11,7 +11,8 @@ author:              Rick Owens
 category:            JSON
 copyright:           2025 Owens Murray, LLC.
 build-type:          Simple
-extra-source-files:
+extra-doc-files:
+  CHANGELOG.md
   README.md
   LICENSE
 

--- a/json-spec.cabal
+++ b/json-spec.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                json-spec
-version:             1.2.0.0
+version:             1.3.0.0
 synopsis:            Type-level JSON specification
 maintainer:          rick@owensmurray.com
 description:         See the README at: https://github.com/owensmurray/json-spec#json-spec

--- a/json-spec.cabal
+++ b/json-spec.cabal
@@ -9,7 +9,7 @@ license:             MIT
 license-file:        LICENSE
 author:              Rick Owens
 category:            JSON
-copyright:           2025 Owens Murray, LLC.
+copyright:           2026 Owens Murray, LLC.
 build-type:          Simple
 extra-doc-files:
   CHANGELOG.md

--- a/test/jsonspec.hs
+++ b/test/jsonspec.hs
@@ -6,8 +6,8 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeAbstractions #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -19,7 +19,6 @@
   be disabled individually, but then we re-enable the specific warnings
   we most care about.
 -}
-{-# OPTIONS_GHC -Wwarn #-}
 {-# OPTIONS_GHC -Werror=missing-import-lists #-}
 
 module Main (main) where
@@ -37,7 +36,8 @@ import Data.JsonSpec
     , JsonLet, JsonNullable, JsonNum, JsonObject, JsonRaw, JsonRef, JsonString
     , JsonTag
     )
-  , Tag(Tag), (:::), (::?), eitherDecode, encode, unField
+  , Tag(Tag), (:::), (::?), eitherDecode
+  , encode, unField
   )
 import Data.Proxy (Proxy(Proxy))
 import Data.Scientific (Scientific)
@@ -690,16 +690,18 @@ data TestSum
 instance HasJsonEncodingSpec TestSum where
   type EncodingSpec TestSum =
     JsonEither
-      (JsonObject '[
-        Required "tag" (JsonTag "a"),
-        Required "content" (JsonObject [
-          Required "int-field" JsonInt,
-          Required "txt-field" JsonString
-        ])
-      ])
-      (JsonObject '[
-        Required "tag" (JsonTag "b")
-      ])
+      '[
+        JsonObject '[
+          Required "tag" (JsonTag "a"),
+          Required "content" (JsonObject [
+            Required "int-field" JsonInt,
+            Required "txt-field" JsonString
+          ])
+        ],
+        JsonObject '[
+          Required "tag" (JsonTag "b")
+        ]
+      ]
   toJSONStructure = \case
     TestA i t ->
       Left


### PR DESCRIPTION
JsonEither now accepts a type-level list of specs (JsonEither '[a, b, c])
instead of two arguments, so sum types with many branches no longer
require a binary tree of nested JsonEithers. Structural type: two or more
branches map to nested Either; a single branch maps to JStruct env spec
(no sum wrapper). Empty list is a type error.

CHANGELOG under Unreleased with migration guide. Add extra-doc-files
(include CHANGELOG.md) to cabal.

Teardown: feature commit (changelog under Unreleased).
Co-authored-by: Cursor <cursoragent@cursor.com>